### PR TITLE
Fix exception if no state can be loaded.

### DIFF
--- a/Screenkey/screenkey.py
+++ b/Screenkey/screenkey.py
@@ -160,7 +160,7 @@ class Screenkey(gtk.Window):
             self.logger.debug("file %s is invalid." % self.STATE_FILE)
 
         # compatibility with previous versions (0.5)
-        if options.key_mode == 'normal':
+        if options and options.key_mode == 'normal':
             options.key_mode = 'composed'
 
         return options


### PR DESCRIPTION
Without it crashes with following:

```
Traceback (most recent call last):
  File "./screenkey", line 100, in <module>
    main()
  File "./screenkey", line 92, in main
    sc.Screenkey(logger=logger, options=options, show_settings=args.show_settings)
  File "/home/s.seletskiy/sources/screenkey-wavxx/Screenkey/screenkey.py", line 87, in __init__
    self.options = self.load_state()
  File "/home/s.seletskiy/sources/screenkey-wavxx/Screenkey/screenkey.py", line 163, in load_state
    if options.key_mode == 'normal':
AttributeError: 'NoneType' object has no attribute 'key_mode'
```
