### PR TITLE
Fix exit on Ctrl+C from the terminal where app was started

### DIFF
--- a/Screenkey/screenkey.py
+++ b/Screenkey/screenkey.py
@@ -12,6 +12,7 @@ from threading import Timer
 import json
 import os
 import subprocess
+import signal
 
 import glib
 glib.threads_init()
@@ -742,4 +743,5 @@ class Screenkey(gtk.Window):
 
 
 def run():
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
     gtk.main()


### PR DESCRIPTION
When starting screenkey from an open terminal, python creates KeyboardInterrupt-raising SIGINT handler, which does not work well with GTK.
As there's no value in raising KeyboardInterrupt here, simple solution is to reset handler to its default before entering gtk eventloop.

To test, run e.g. `screenkey --no-detach ...` in the terminal and try to Ctrl+C it before/after the patch.

Not sure if starting thing from terminal is that common use-case, but that's definitely most convenient way to set/repeat various parameters for me.

Thanks!