### PR TITLE
Show modifiers only

### DIFF
--- a/Screenkey/screenkey.py
+++ b/Screenkey/screenkey.py
@@ -279,17 +279,10 @@ class Screenkey(gtk.Window):
         self.label.set_text(text)
         self.label.set_attributes(attr)
 
-        if not self.get_property('visible'):
+        if markup == '' and self.get_property('visible'):
+            self.hide()
+        elif markup != '' and not self.get_property('visible'):
             self.show()
-        if self.timer_hide:
-            self.timer_hide.cancel()
-        if self.options.timeout > 0:
-            self.timer_hide = Timer(self.options.timeout, self.on_timeout_main)
-            self.timer_hide.start()
-        if self.timer_min:
-            self.timer_min.cancel()
-        self.timer_min = Timer(self.options.recent_thr * 2, self.on_timeout_min)
-        self.timer_min.start()
 
 
     def on_timeout_main(self):

--- a/Screenkey/screenkey.py
+++ b/Screenkey/screenkey.py
@@ -96,8 +96,11 @@ class Screenkey(gtk.Window):
         self.set_active_monitor(self.options.screen)
 
         cmap = scr.get_rgba_colormap()
-        if cmap is not None:
+        if cmap is None:
+            self.logger.debug("Cannot set transparency")
+        else:
             self.set_colormap(cmap)
+            self.logger.debug("Set tansparency")
 
         self.labelmngr = None
         self.enabled = True
@@ -174,6 +177,7 @@ class Screenkey(gtk.Window):
 
 
     def update_label(self):
+        self.logger.debug("update_label")
         attr = self.label.get_attributes()
         text = self.label.get_text()
         self.override_font_attributes(attr, text)
@@ -186,6 +190,7 @@ class Screenkey(gtk.Window):
 
 
     def on_expose(self, widget, *_):
+        self.logger.debug("on_expose")
         ctx = widget.get_window().cairo_create()
         ctx.set_source_rgba(self.bg_color.red_float,
                             self.bg_color.green_float,
@@ -251,6 +256,7 @@ class Screenkey(gtk.Window):
 
 
     def show(self):
+        self.logger.debug("show")
         super(Screenkey, self).show()
 
 


### PR DESCRIPTION
Hi, thanks for the nice program!

I wanted to use it for something a little bit different:

- Only show modifier keys
- Show the overlay window immediately when a modifier key is pressed
- Hide the overlay window immediately when all modifier keys are released.

This PR isn't intended to be merged, but it shows how I achieved this.  If there is interest, and someone can give me a bit of guidance on a decent way to pass "key released" events through the program's various layers, I could work on turning this into a set of options that enable this mode.

I also wanted to make the overlay window transparent except for the text, but I could not get this work (see notes under 5e0898f for details).  In fact the existing opacity setting does not work for me either, even though my WM supports transparency and the `scr.get_rgba_colormap()` operation succeeds.